### PR TITLE
Make the text entry for the Add Note multiline

### DIFF
--- a/src/UpdateRequestDialog.tsx
+++ b/src/UpdateRequestDialog.tsx
@@ -536,6 +536,7 @@ function UpdateRequestDialog(props: SimpleDialogProps & ILocalizeProps) {
                       fullWidth
                       label="New note"
                       variant="outlined"
+                      multiline
                       value={currentNote}
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                         setCurrentNote(e.currentTarget.value);


### PR DESCRIPTION
* This will allow long notes to be visible when they are created